### PR TITLE
wire swipe deck to API, add feedback pipeline, filters, and image domains

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "images.unsplash.com" },
+      { protocol: "https", hostname: "www.na-kd.com" },
+      { protocol: "https", hostname: "na-kd.com" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { UserEvent } from "@/lib/events";
+import { recordEvents } from "@/lib/metrics";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const events = Array.isArray(body?.events) ? (body.events as UserEvent[]) : [];
+
+    if (!events.length) {
+      return NextResponse.json({ status: "no_events" }, { status: 200 });
+    }
+
+    recordEvents(events);
+
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    console.error("/api/feedback error", error);
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+}

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { getMetrics } from "@/lib/metrics";
+
+export async function GET() {
+  return NextResponse.json({ metrics: getMetrics() });
+}

--- a/src/app/api/recs/next/route.ts
+++ b/src/app/api/recs/next/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { Item } from "@/lib/events";
+import { incrementMetric } from "@/lib/metrics";
+
+let itemsCache: Item[] | null = null;
+
+async function loadItems(): Promise<Item[]> {
+  if (itemsCache) {
+    return itemsCache;
+  }
+
+  const filePath = path.join(process.cwd(), "src/mock/items.json");
+  const fileContents = await fs.readFile(filePath, "utf-8");
+  const parsed: Item[] = JSON.parse(fileContents);
+  itemsCache = parsed;
+  return parsed;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const { user_id: userId, k } = body as { user_id?: string; k?: number };
+
+    const items = await loadItems();
+    const desired = Number.isInteger(k) && (k as number) > 0 ? (k as number) : 10;
+
+    const recommendations = Array.from({ length: desired }, (_, index) => {
+      const item = items[index % items.length];
+      const score = Math.max(0, 1 - index * 0.05);
+      const itemWithScore: Item = { ...item, score };
+      return {
+        item: itemWithScore,
+        score,
+      };
+    });
+
+    incrementMetric("impressions", recommendations.length);
+
+    return NextResponse.json({ recommendations });
+  } catch (error) {
+    console.error("/api/recs/next error", error);
+    return NextResponse.json({ error: "unable_to_fetch_recommendations" }, { status: 500 });
+  }
+}

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -1,31 +1,468 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import SwipeDeck from "../../components/SwipeDeck/SwipeDeck";
-import { useEffect, useState } from "react";
 import { Item } from "../../lib/events";
+import { fetchNextItems, emitShare, sendFeedback } from "../../lib/recs";
+import { useCartStore, useLikesStore, useUserStore } from "../../lib/store";
+
+const DECK_SIZE = 10;
+const BASE_GENDERS = ["female", "male", "unisex"] as const;
+const BASE_SIZES = ["xs", "s", "m", "l", "xl", "xxl"];
 
 const ItemsPage = () => {
-  const [items, setItems] = useState<Item[]>([]);
+  const userId = useUserStore((state) => state.userId);
+  const likes = useLikesStore((state) => state.likes);
+  const addLike = useLikesStore((state) => state.add);
+  const addToCart = useCartStore((state) => state.add);
+  const [sourceItems, setSourceItems] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [priceBounds, setPriceBounds] = useState<[number, number]>([0, 0]);
+  const [filters, setFilters] = useState({
+    gender: "all" as "all" | "female" | "male" | "unisex",
+    price: [0, 0] as [number, number],
+    brand: "all" as "all" | string,
+    size: "all" as "all" | string,
+  });
+  const [activeModal, setActiveModal] = useState<
+    null | "gender" | "price" | "brand" | "size"
+  >(null);
+  const [tempPriceRange, setTempPriceRange] = useState<[number, number]>([0, 0]);
 
   useEffect(() => {
-    // Fetch items (mocked for now)
-    setItems([
+    let isMounted = true;
+    console.log("[ItemsPage] request new deck", { userId });
+
+    async function loadItems() {
+      try {
+        setLoading(true);
+        console.log("[ItemsPage] fetching recommendations", { deckSize: DECK_SIZE });
+        const nextItems = await fetchNextItems(userId, DECK_SIZE, { surface: "items" });
+        console.log("[ItemsPage] fetched recommendations", nextItems);
+        if (isMounted) {
+          setSourceItems(nextItems.slice(0, DECK_SIZE));
+          const prices = nextItems.map((item) => item.price_usd);
+          const minPrice = Math.min(...prices);
+          const maxPrice = Math.max(...prices);
+          setPriceBounds([minPrice, maxPrice]);
+          setFilters((prev) => ({
+            ...prev,
+            price:
+              prev.price[0] === 0 && prev.price[1] === 0
+                ? [minPrice, maxPrice]
+                : prev.price,
+          }));
+        }
+      } catch (error) {
+        console.error("[ItemsPage] failed to load items", error);
+        if (isMounted) {
+          setSourceItems([]);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadItems();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  const likesCount = useMemo(() => likes.length, [likes]);
+
+  const normalizeBrand = (brand?: string) => (brand && brand.trim() ? brand : "NA-KD");
+
+  const itemGender = (item: Item) => {
+    const attrs = (item.attributes || {}) as {
+      gender?: string;
+    };
+    const genderValue = attrs.gender?.toLowerCase();
+    if (genderValue === "female" || genderValue === "male" || genderValue === "unisex") {
+      return genderValue;
+    }
+    return "unisex";
+  };
+
+  const itemSizes = (item: Item) => {
+    const attrs = (item.attributes || {}) as {
+      sizes?: unknown;
+    };
+    if (Array.isArray(attrs.sizes)) {
+      return attrs.sizes.map((size) => String(size).toLowerCase());
+    }
+    return [];
+  };
+
+  const filteredItems = useMemo(() => {
+    const [minSelected, maxSelected] = filters.price;
+
+    return sourceItems.filter((item) => {
+      const genderMatch =
+        filters.gender === "all" || itemGender(item) === filters.gender;
+
+      const brandMatch =
+        filters.brand === "all" || normalizeBrand(item.brand) === filters.brand;
+
+      const sizeMatch =
+        filters.size === "all" || itemSizes(item).includes(filters.size);
+
+      const priceMatch =
+        item.price_usd >= (minSelected ?? priceBounds[0]) &&
+        item.price_usd <= (maxSelected ?? priceBounds[1]);
+
+      return genderMatch && brandMatch && sizeMatch && priceMatch;
+    });
+  }, [sourceItems, filters, priceBounds]);
+
+  const deckItems = useMemo(
+    () => filteredItems.slice(0, DECK_SIZE),
+    [filteredItems]
+  );
+
+  const genderOptions = useMemo(() => {
+    const set = new Set<string>(BASE_GENDERS);
+    sourceItems.forEach((item) => set.add(itemGender(item)));
+    return Array.from(set);
+  }, [sourceItems]);
+
+  const brandOptions = useMemo(() => {
+    const set = new Set<string>();
+    sourceItems.forEach((item) => set.add(normalizeBrand(item.brand)));
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [sourceItems]);
+
+  const sizeOptions = useMemo(() => {
+    const set = new Set<string>(BASE_SIZES);
+    sourceItems.forEach((item) => {
+      itemSizes(item).forEach((size) => set.add(size));
+    });
+    const order = new Map(BASE_SIZES.map((size, index) => [size, index] as const));
+    return Array.from(set).sort((a, b) => {
+      const aIndex = order.get(a) ?? Number.MAX_SAFE_INTEGER;
+      const bIndex = order.get(b) ?? Number.MAX_SAFE_INTEGER;
+      if (aIndex !== bIndex) return aIndex - bIndex;
+      return a.localeCompare(b);
+    });
+  }, [sourceItems]);
+
+  const handleSwipeRight = (item: Item) => {
+    console.log("[ItemsPage] swipe right", item);
+    addLike(item);
+    void sendFeedback([
       {
-        item_id: "1",
-        title: "Sample Item",
-        price_usd: 19.99,
-        image_url: "/sample.jpg",
+        type: "swipe_like",
+        user_id: userId,
+        item_id: item.item_id,
+        surface: "items",
+        ts: Date.now(),
       },
     ]);
-  }, []);
+  };
+
+  const handleSwipeLeft = (item: Item) => {
+    console.log("[ItemsPage] swipe left", item);
+    void sendFeedback([
+      {
+        type: "swipe_dislike",
+        user_id: userId,
+        item_id: item.item_id,
+        surface: "items",
+        ts: Date.now(),
+      },
+    ]);
+  };
+
+  const handleAddToCart = (item: Item) => {
+    console.log("[ItemsPage] add to cart", item);
+    addToCart(item);
+    void sendFeedback([
+      {
+        type: "add_to_cart",
+        user_id: userId,
+        item_id: item.item_id,
+        ts: Date.now(),
+      },
+    ]);
+  };
+
+  const handleShare = (item: Item) => {
+    console.log("[ItemsPage] share", item);
+    void emitShare(userId, item.item_id);
+  };
+
+  console.log("[ItemsPage] render", {
+    loading,
+    itemsCount: deckItems.length,
+  });
+
+  const openModal = (modal: typeof activeModal) => {
+    if (modal === "price") {
+      setTempPriceRange([...filters.price] as [number, number]);
+    }
+    setActiveModal(modal);
+  };
+
+  const closeModal = () => setActiveModal(null);
+
+  const renderModal = () => {
+    if (!activeModal) return null;
+
+    const FilterModal = ({
+      title,
+      children,
+    }: {
+      title: string;
+      children: ReactNode;
+    }) => (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+        <div className="w-full max-w-md rounded-3xl bg-white p-6 text-gray-900 shadow-2xl">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">{title}</h2>
+            <button
+              type="button"
+              onClick={closeModal}
+              className="rounded-full p-2 text-gray-500 hover:bg-gray-100"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="mt-4">{children}</div>
+        </div>
+      </div>
+    );
+
+    if (activeModal === "gender") {
+      const allOptions = ["all", ...genderOptions];
+      return (
+        <FilterModal title="Select Gender">
+          <div className="grid gap-2">
+            {allOptions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => {
+                  setFilters((prev) => ({ ...prev, gender: option as typeof prev.gender }));
+                  closeModal();
+                }}
+                className={`rounded-xl px-4 py-3 text-left text-sm font-semibold transition ${
+                  filters.gender === option
+                    ? "bg-indigo-500 text-white"
+                    : "bg-gray-100 text-gray-800 hover:bg-gray-200"
+                }`}
+              >
+                {option === "all" ? "All" : option.charAt(0).toUpperCase() + option.slice(1)}
+              </button>
+            ))}
+          </div>
+        </FilterModal>
+      );
+    }
+
+    if (activeModal === "brand") {
+      const allOptions = ["all", ...brandOptions];
+      return (
+        <FilterModal title="Select Brand">
+          <div className="grid gap-2">
+            {allOptions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => {
+                  setFilters((prev) => ({
+                    ...prev,
+                    brand: option as typeof prev.brand,
+                  }));
+                  closeModal();
+                }}
+                className={`rounded-xl px-4 py-3 text-left text-sm font-semibold transition ${
+                  filters.brand === option
+                    ? "bg-indigo-500 text-white"
+                    : "bg-gray-100 text-gray-800 hover:bg-gray-200"
+                }`}
+              >
+                {option === "all" ? "All Brands" : option}
+              </button>
+            ))}
+          </div>
+        </FilterModal>
+      );
+    }
+
+    if (activeModal === "size") {
+      const allOptions = ["all", ...sizeOptions];
+      return (
+        <FilterModal title="Select Size">
+          <div className="grid grid-cols-3 gap-2">
+            {allOptions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => {
+                  setFilters((prev) => ({
+                    ...prev,
+                    size: option as typeof prev.size,
+                  }));
+                  closeModal();
+                }}
+                className={`rounded-xl px-4 py-3 text-center text-sm font-semibold uppercase transition ${
+                  filters.size === option
+                    ? "bg-indigo-500 text-white"
+                    : "bg-gray-100 text-gray-800 hover:bg-gray-200"
+                }`}
+              >
+                {option === "all" ? "All" : option}
+              </button>
+            ))}
+          </div>
+        </FilterModal>
+      );
+    }
+
+    if (activeModal === "price") {
+      const [minBound, maxBound] = priceBounds;
+      const [minValue, maxValue] = tempPriceRange;
+
+      const handleMinChange = (value: number) => {
+        setTempPriceRange(([_, max]) => [Math.min(value, max), max]);
+      };
+
+      const handleMaxChange = (value: number) => {
+        setTempPriceRange(([min, _]) => [min, Math.max(value, min)]);
+      };
+
+      return (
+        <FilterModal title="Select Price Range">
+          <div className="space-y-6">
+            <div className="flex items-center justify-between text-sm font-semibold text-gray-700">
+              <span>${Math.round(minValue)}</span>
+              <span>${Math.round(maxValue)}</span>
+            </div>
+            <div className="space-y-3">
+              <input
+                type="range"
+                min={minBound}
+                max={maxBound}
+                value={minValue}
+                onChange={(event) => handleMinChange(Number(event.target.value))}
+                className="w-full"
+              />
+              <input
+                type="range"
+                min={minBound}
+                max={maxBound}
+                value={maxValue}
+                onChange={(event) => handleMaxChange(Number(event.target.value))}
+                className="w-full"
+              />
+            </div>
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <input
+                type="number"
+                value={minValue}
+                min={minBound}
+                max={maxValue}
+                onChange={(event) => handleMinChange(Number(event.target.value))}
+                className="w-full rounded-xl border border-gray-300 px-3 py-2"
+              />
+              <span className="px-2 text-gray-500">to</span>
+              <input
+                type="number"
+                value={maxValue}
+                min={minValue}
+                max={maxBound}
+                onChange={(event) => handleMaxChange(Number(event.target.value))}
+                className="w-full rounded-xl border border-gray-300 px-3 py-2"
+              />
+            </div>
+            <div className="flex justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setTempPriceRange([...priceBounds] as [number, number]);
+                }}
+                className="flex-1 rounded-xl border border-gray-200 px-4 py-3 text-sm font-semibold text-gray-700"
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setFilters((prev) => ({
+                    ...prev,
+                    price: [...tempPriceRange] as [number, number],
+                  }));
+                  closeModal();
+                }}
+                className="flex-1 rounded-xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </FilterModal>
+      );
+    }
+
+    return null;
+  };
 
   return (
-    <div className="p-4">
-      <header className="flex justify-between items-center mb-4">
+    <div className="flex min-h-screen flex-col p-4 pb-28">
+      <header className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Clozyt</h1>
-        <span className="text-sm">❤️ 0</span>
+        <span className="text-sm text-gray-500">❤️ {likesCount}</span>
       </header>
-      <SwipeDeck items={items} />
+      <div className="relative flex-1 overflow-hidden">
+        {loading && deckItems.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-gray-500">
+            Loading recommendations...
+          </div>
+        ) : (
+          <SwipeDeck
+            items={deckItems}
+            onSwipeLeft={handleSwipeLeft}
+            onSwipeRight={handleSwipeRight}
+            onAddToCart={handleAddToCart}
+            onShare={handleShare}
+          />
+        )}
+      </div>
+      <div className="mt-5 grid grid-cols-4 gap-2 pb-4">
+        <button
+          type="button"
+          onClick={() => openModal("gender")}
+          className="rounded-xl bg-white/20 py-3 text-center text-xs font-semibold uppercase tracking-wide text-white shadow-md transition hover:bg-white/30"
+        >
+          Gender
+        </button>
+        <button
+          type="button"
+          onClick={() => openModal("price")}
+          className="rounded-xl bg-white/20 py-3 text-center text-xs font-semibold uppercase tracking-wide text-white shadow-md transition hover:bg-white/30"
+        >
+          Price
+        </button>
+        <button
+          type="button"
+          onClick={() => openModal("brand")}
+          className="rounded-xl bg-white/20 py-3 text-center text-xs font-semibold uppercase tracking-wide text-white shadow-md transition hover:bg-white/30"
+        >
+          Brand
+        </button>
+        <button
+          type="button"
+          onClick={() => openModal("size")}
+          className="rounded-xl bg-white/20 py-3 text-center text-xs font-semibold uppercase tracking-wide text-white shadow-md transition hover:bg-white/30"
+        >
+          Size
+        </button>
+      </div>
+      {renderModal()}
     </div>
   );
 };

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,18 +1,47 @@
+"use client";
+
 import LikedList from "../../components/lists/LikedList";
 import CartList from "../../components/lists/CartList";
+import { useCartStore, useUserStore } from "../../lib/store";
+import { sendFeedback } from "../../lib/recs";
 
 const PortfolioPage = () => {
+  const cart = useCartStore((state) => state.cart);
+  const userId = useUserStore((state) => state.userId);
+
+  const handleBuyCart = () => {
+    if (!cart.length) return;
+
+    const cartItemIds = cart.flatMap((entry) =>
+      Array.from({ length: entry.qty }, () => entry.item.item_id)
+    );
+
+    void sendFeedback([
+      {
+        type: "purchase",
+        user_id: userId,
+        cart_item_ids: cartItemIds,
+        ts: Date.now(),
+      },
+    ]);
+  };
+
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Portfolio</h1>
+      <h1 className="mb-4 text-2xl font-bold">Portfolio</h1>
       <section className="mb-8">
-        <h2 className="text-xl font-semibold mb-2">Liked Items</h2>
+        <h2 className="mb-2 text-xl font-semibold">Liked Items</h2>
         <LikedList />
       </section>
       <section>
-        <h2 className="text-xl font-semibold mb-2">Cart</h2>
+        <h2 className="mb-2 text-xl font-semibold">Cart</h2>
         <CartList />
-        <button className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md shadow hover:bg-indigo-700">
+        <button
+          type="button"
+          onClick={handleBuyCart}
+          disabled={!cart.length}
+          className="mt-4 rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+        >
           Buy Cart
         </button>
       </section>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,15 +1,45 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import CollageGrid from "../../components/grids/CollageGrid";
+import itemsData from "@/mock/items.json";
+import { Item } from "../../lib/events";
+
+const allItems = itemsData as Item[];
+
+const searchableText = (item: Item) => {
+  const attributes = Object.values(item.attributes ?? {})
+    .filter((value) => typeof value === "string")
+    .join(" ");
+  const tags = item.tags?.join(" ") ?? "";
+  return `${item.title} ${item.brand} ${item.category ?? ""} ${tags} ${attributes} ${item.price_usd}`.toLowerCase();
+};
 
 const SearchPage = () => {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) {
+      return allItems;
+    }
+
+    return allItems.filter((item) => searchableText(item).includes(trimmed));
+  }, [query]);
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Search</h1>
+    <div className="flex min-h-screen flex-col p-4">
+      <h1 className="text-2xl font-bold text-white">Search</h1>
       <input
         type="text"
-        placeholder="Search items..."
-        className="w-full p-2 border border-gray-300 rounded-md mb-4"
+        placeholder="Search items by name, brand, price..."
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        className="mt-4 w-full rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/60 focus:border-white focus:outline-none focus:ring-2 focus:ring-white/70"
       />
-      <CollageGrid />
+      <div className="mt-6 flex-1">
+        <CollageGrid items={filtered} />
+      </div>
     </div>
   );
 };

--- a/src/components/SwipeDeck/ProductCard.tsx
+++ b/src/components/SwipeDeck/ProductCard.tsx
@@ -1,27 +1,66 @@
 import Image from "next/image";
-import { ShoppingCart } from "lucide-react";
+import { ShoppingCart, Share2 } from "lucide-react";
 import { Item } from "../../lib/events";
 
-const ProductCard = ({ item }: { item: Item }) => {
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+type ProductCardProps = {
+  item: Item;
+  onAddToCart?: () => void;
+  onShare?: () => void;
+};
+
+const ProductCard = ({ item, onAddToCart, onShare }: ProductCardProps) => {
+  const priceLabel = currency.format(item.price_usd);
+
+  const handleAddToCart = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onAddToCart?.();
+  };
+
+  const handleShare = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onShare?.();
+  };
+
   return (
-    <div className="relative w-full h-full rounded-2xl shadow-lg overflow-hidden">
+    <div className="relative h-full w-full overflow-hidden rounded-3xl shadow-xl">
       <Image
         src={item.image_url}
         alt={item.title}
-        layout="fill"
-        objectFit="cover"
-        className="absolute inset-0"
+        fill
+        sizes="(max-width: 768px) 100vw, 480px"
+        className="object-cover"
+        priority={false}
       />
-      <div className="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black to-transparent p-4">
-        <h3 className="text-white font-semibold drop-shadow-md">{item.title}</h3>
-        <p className="text-white/90 drop-shadow-md">${item.price_usd.toFixed(2)}</p>
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-6 text-white">
+        <div className="space-y-1">
+          <h3 className="text-xl font-semibold leading-tight">{item.title}</h3>
+          <p className="text-sm text-white/80">{item.brand || "NA-KD"}</p>
+          <p className="text-lg font-medium">{priceLabel}</p>
+        </div>
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={handleAddToCart}
+            className="flex flex-1 items-center justify-center gap-2 rounded-md bg-indigo-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-indigo-600"
+          >
+            <ShoppingCart size={16} />
+            Add to Cart
+          </button>
+          <button
+            type="button"
+            onClick={handleShare}
+            className="flex items-center justify-center gap-2 rounded-md bg-white/20 px-3 py-2 text-sm font-medium text-white transition hover:bg-white/30"
+          >
+            <Share2 size={16} />
+            Share
+          </button>
+        </div>
       </div>
-      <button
-        className="absolute bottom-4 right-4 w-14 h-14 bg-indigo-600 text-white rounded-full flex items-center justify-center shadow-md"
-        aria-label="Add to Cart"
-      >
-        <ShoppingCart size={24} />
-      </button>
     </div>
   );
 };

--- a/src/components/SwipeDeck/SwipeDeck.tsx
+++ b/src/components/SwipeDeck/SwipeDeck.tsx
@@ -1,48 +1,151 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useGesture } from "@use-gesture/react";
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import ProductCard from "./ProductCard";
 import Overlays from "./Overlays";
 import { Item } from "../../lib/events";
 
+type SwipeDeckProps = {
+  items: Item[];
+  onSwipeLeft?: (item: Item) => void;
+  onSwipeRight?: (item: Item) => void;
+  onAddToCart?: (item: Item) => void;
+  onShare?: (item: Item) => void;
+};
 
-const SwipeDeck = ({ items }: { items: Item[] }) => {
+const SwipeDeck = ({
+  items,
+  onSwipeLeft,
+  onSwipeRight,
+  onAddToCart,
+  onShare,
+}: SwipeDeckProps) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [direction, setDirection] = useState<"left" | "right" | null>(null);
-
-  const gestureRef = useRef<HTMLDivElement>(null);
-
-  useGesture(
-    {
-      onDrag: ({ movement: [mx], velocity: [vx], direction: [dx] }) => {
-        if (Math.abs(mx) > 120 || Math.abs(vx) > 0.5) {
-          setDirection(dx > 0 ? "right" : "left");
-          setCurrentIndex((prev) => prev + 1);
-        }
-      },
-    },
-    { target: gestureRef }
+  const [leavingDirection, setLeavingDirection] = useState<"left" | "right" | null>(
+    null
   );
-
+  const [leavingItemId, setLeavingItemId] = useState<string | null>(null);
   const currentItem = items[currentIndex];
 
+  useEffect(() => {
+    setCurrentIndex(0);
+    setLeavingDirection(null);
+    setLeavingItemId(null);
+    console.log("[SwipeDeck] received new items", { count: items.length });
+  }, [items]);
+
+  console.log("[SwipeDeck] render", {
+    itemsCount: items.length,
+    currentIndex,
+    hasCurrentItem: Boolean(currentItem),
+  });
+
+  const finalizeSwipe = useCallback(
+    (direction: "left" | "right", item: Item) => {
+      setLeavingDirection(direction);
+      setLeavingItemId(item.item_id);
+
+      if (direction === "left") {
+        onSwipeLeft?.(item);
+      } else {
+        onSwipeRight?.(item);
+      }
+
+      setCurrentIndex((prev) => prev + 1);
+
+      setTimeout(() => {
+        setLeavingDirection(null);
+        setLeavingItemId(null);
+      }, 300);
+    },
+    [onSwipeLeft, onSwipeRight]
+  );
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!currentItem) return;
+
+      if ((event.target as HTMLElement).closest("button")) {
+        return;
+      }
+
+      const { left, width } = event.currentTarget.getBoundingClientRect();
+      const relativeX = event.clientX - left;
+      const third = width / 3;
+
+      if (relativeX < third) {
+        finalizeSwipe("left", currentItem);
+      } else if (relativeX > 2 * third) {
+        finalizeSwipe("right", currentItem);
+      }
+    },
+    [currentItem, finalizeSwipe]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!currentItem) return;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        finalizeSwipe("left", currentItem);
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        finalizeSwipe("right", currentItem);
+      }
+    },
+    [currentItem, finalizeSwipe]
+  );
+
+  const bind = useGesture({
+    onDragEnd: ({ movement: [mx], velocity: [vx], direction: [dx] }) => {
+      if (!currentItem) return;
+      const shouldSwipe = Math.abs(mx) > 80 || Math.abs(vx) > 0.5;
+      if (!shouldSwipe) {
+        return;
+      }
+      const direction = dx > 0 ? "right" : "left";
+      finalizeSwipe(direction, currentItem);
+    },
+  });
+
+  const exitX = useMemo(() => {
+    if (leavingDirection === "right") return 300;
+    if (leavingDirection === "left") return -300;
+    return 0;
+  }, [leavingDirection]);
+
   return (
-    <div className="relative w-full h-full">
-      <AnimatePresence>
+    <div
+      className="relative h-full w-full min-h-[70vh]"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role="presentation"
+    >
+      <AnimatePresence mode="wait">
         {currentItem && (
           <motion.div
             key={currentItem.item_id}
-            ref={gestureRef} // Attach gesture handling via useRef
-            className="absolute inset-0"
+            className="absolute inset-0 flex h-full"
             initial={{ x: 0, opacity: 1 }}
             animate={{ x: 0, opacity: 1 }}
-            exit={{ x: direction === "right" ? 300 : -300, opacity: 0 }}
-            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            exit={{ x: exitX, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 260, damping: 30 }}
+            {...bind()}
           >
-            <ProductCard item={currentItem} />
-            <Overlays direction={direction} />
+            <ProductCard
+              item={currentItem}
+              onAddToCart={() => onAddToCart?.(currentItem)}
+              onShare={() => onShare?.(currentItem)}
+            />
+            <Overlays
+              direction={
+                leavingItemId === currentItem.item_id ? leavingDirection : null
+              }
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/forms/ProfileForm.tsx
+++ b/src/components/forms/ProfileForm.tsx
@@ -1,58 +1,229 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { sendFeedback } from "../../lib/recs";
+import { useUserStore, UserProfile } from "../../lib/store";
+
+const styleOptions = ["minimal", "streetwear", "casual", "formal", "sporty", "boho"] as const;
+
+type FormState = {
+  name: string;
+  email: string;
+  gender: UserProfile["gender"];
+  age: string;
+  budgetMin: string;
+  budgetMax: string;
+  styles: string[];
+};
+
+const asNumber = (value: string) => {
+  if (!value.trim()) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
 
 const ProfileForm = () => {
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    preferences: [],
+  const profile = useUserStore((state) => state.profile);
+  const setProfile = useUserStore((state) => state.setProfile);
+  const userId = useUserStore((state) => state.userId);
+
+  const [formState, setFormState] = useState<FormState>({
+    name: profile.name,
+    email: profile.email,
+    gender: profile.gender,
+    age: profile.age ? String(profile.age) : "",
+    budgetMin: profile.budgetMin ? String(profile.budgetMin) : "",
+    budgetMax: profile.budgetMax ? String(profile.budgetMax) : "",
+    styles: profile.styles ?? [],
   });
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+  useEffect(() => {
+    setFormState({
+      name: profile.name,
+      email: profile.email,
+      gender: profile.gender,
+      age: profile.age ? String(profile.age) : "",
+      budgetMin: profile.budgetMin ? String(profile.budgetMin) : "",
+      budgetMax: profile.budgetMax ? String(profile.budgetMax) : "",
+      styles: profile.styles ?? [],
+    });
+  }, [profile]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    console.log("Form submitted", formData);
+  const toggleStyle = (style: string) => {
+    setFormState((prev) => {
+      const styles = prev.styles.includes(style)
+        ? prev.styles.filter((tag) => tag !== style)
+        : [...prev.styles, style];
+      return { ...prev, styles };
+    });
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const ageNumber = asNumber(formState.age);
+    const budgetMinNumber = asNumber(formState.budgetMin);
+    const budgetMaxNumber = asNumber(formState.budgetMax);
+
+    const nextProfile: UserProfile = {
+      name: formState.name.trim(),
+      email: formState.email.trim(),
+      gender: formState.gender,
+      styles: formState.styles,
+      ...(ageNumber !== undefined ? { age: ageNumber } : {}),
+      ...(budgetMinNumber !== undefined ? { budgetMin: budgetMinNumber } : {}),
+      ...(budgetMaxNumber !== undefined ? { budgetMax: budgetMaxNumber } : {}),
+    };
+
+    setProfile(nextProfile);
+
+    await sendFeedback([
+      {
+        type: "profile_update",
+        user_id: userId,
+        ts: Date.now(),
+        profile: {
+          name: nextProfile.name || undefined,
+          email: nextProfile.email || undefined,
+          gender: nextProfile.gender,
+          styles: nextProfile.styles.length ? nextProfile.styles : undefined,
+          age: nextProfile.age,
+          budgetMin: nextProfile.budgetMin,
+          budgetMax: nextProfile.budgetMax,
+        },
+      },
+    ]);
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="name" className="block text-sm font-medium">
+        <label htmlFor="name" className="block text-sm font-medium text-gray-700">
           Name
         </label>
         <input
-          type="text"
           id="name"
           name="name"
-          value={formData.name}
+          type="text"
+          value={formState.name}
           onChange={handleChange}
-          className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
       </div>
       <div>
-        <label htmlFor="email" className="block text-sm font-medium">
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
           Email
         </label>
         <input
-          type="email"
           id="email"
           name="email"
-          value={formData.email}
+          type="email"
+          value={formState.email}
           onChange={handleChange}
-          className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
       </div>
-      <button
-        type="submit"
-        className="px-4 py-2 bg-indigo-600 text-white rounded-md shadow hover:bg-indigo-700"
-      >
-        Save
-      </button>
+      <div>
+        <label htmlFor="gender" className="block text-sm font-medium text-gray-700">
+          Gender
+        </label>
+        <select
+          id="gender"
+          name="gender"
+          value={formState.gender}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          <option value="female">Female</option>
+          <option value="male">Male</option>
+          <option value="nonbinary">Non-binary</option>
+          <option value="prefer_not">Prefer not to say</option>
+        </select>
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor="age" className="block text-sm font-medium text-gray-700">
+            Age
+          </label>
+          <input
+            id="age"
+            name="age"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={formState.age}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="budgetMin" className="block text-sm font-medium text-gray-700">
+            Budget Min (USD)
+          </label>
+          <input
+            id="budgetMin"
+            name="budgetMin"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={formState.budgetMin}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="budgetMax" className="block text-sm font-medium text-gray-700">
+            Budget Max (USD)
+          </label>
+          <input
+            id="budgetMax"
+            name="budgetMax"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={formState.budgetMax}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+      <div>
+        <span className="block text-sm font-medium text-gray-700">Style Tags</span>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {styleOptions.map((style) => {
+            const isSelected = formState.styles.includes(style);
+            return (
+              <button
+                key={style}
+                type="button"
+                onClick={() => toggleStyle(style)}
+                className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                  isSelected
+                    ? "bg-indigo-600 text-white"
+                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                }`}
+              >
+                {style}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div>
+        <button
+          type="submit"
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700"
+        >
+          Save
+        </button>
+      </div>
     </form>
   );
 };

--- a/src/components/grids/CollageGrid.tsx
+++ b/src/components/grids/CollageGrid.tsx
@@ -1,12 +1,39 @@
-const CollageGrid = () => {
+import Image from "next/image";
+import { Item } from "../../lib/events";
+
+type CollageGridProps = {
+  items: Item[];
+};
+
+const CollageGrid = ({ items }: CollageGridProps) => {
+  if (!items.length) {
+    return (
+      <p className="py-10 text-center text-sm text-white/70">
+        No items match your search.
+      </p>
+    );
+  }
+
   return (
-    <div className="grid grid-cols-2 gap-4">
-      {/* Placeholder for items */}
-      {[...Array(10)].map((_, index) => (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+      {items.map((item) => (
         <div
-          key={index}
-          className="w-full h-40 bg-gray-200 rounded-md shadow-md"
-        ></div>
+          key={item.item_id}
+          className="group relative aspect-[3/4] overflow-hidden rounded-2xl bg-white/10 shadow-lg"
+        >
+          <Image
+            src={item.image_url}
+            alt={item.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            sizes="(max-width: 768px) 50vw, 240px"
+          />
+          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent p-3 text-xs text-white">
+            <p className="font-semibold leading-tight">{item.title}</p>
+            {item.brand ? <p className="text-white/70">{item.brand}</p> : null}
+            <p className="mt-1 font-medium">${item.price_usd.toFixed(2)}</p>
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/src/components/lists/CartList.tsx
+++ b/src/components/lists/CartList.tsx
@@ -1,14 +1,23 @@
+"use client";
+
+import { useCartStore } from "../../lib/store";
+
 const CartList = () => {
+  const cart = useCartStore((state) => state.cart);
+
+  if (!cart.length) {
+    return <p className="text-sm text-gray-500">Your cart is empty.</p>;
+  }
+
   return (
-    <ul className="space-y-4">
-      {/* Placeholder for cart items */}
-      {[...Array(3)].map((_, index) => (
+    <ul className="space-y-3">
+      {cart.map((entry) => (
         <li
-          key={index}
-          className="p-4 bg-gray-100 rounded-md shadow-md flex justify-between items-center"
+          key={entry.item.item_id}
+          className="flex items-center justify-between rounded-md bg-gray-100 px-4 py-3 text-sm shadow"
         >
-          <span>Cart Item {index + 1}</span>
-          <span>Qty: 1</span>
+          <span className="font-medium text-gray-800">{entry.item.title}</span>
+          <span className="text-gray-600">Qty: {entry.qty}</span>
         </li>
       ))}
     </ul>

--- a/src/components/lists/LikedList.tsx
+++ b/src/components/lists/LikedList.tsx
@@ -1,14 +1,33 @@
+"use client";
+
+import { instantBuy } from "../../lib/recs";
+import { useLikesStore, useUserStore } from "../../lib/store";
+
 const LikedList = () => {
+  const likes = useLikesStore((state) => state.likes);
+  const userId = useUserStore((state) => state.userId);
+
+  if (!likes.length) {
+    return <p className="text-sm text-gray-500">No liked items yet.</p>;
+  }
+
+  const handleInstantBuy = async (itemId: string) => {
+    await instantBuy(userId, itemId);
+  };
+
   return (
-    <ul className="space-y-4">
-      {/* Placeholder for liked items */}
-      {[...Array(5)].map((_, index) => (
+    <ul className="space-y-3">
+      {likes.map((item) => (
         <li
-          key={index}
-          className="p-4 bg-gray-100 rounded-md shadow-md flex justify-between items-center"
+          key={item.item_id}
+          className="flex items-center justify-between rounded-md bg-gray-100 px-4 py-3 text-sm shadow"
         >
-          <span>Liked Item {index + 1}</span>
-          <button className="px-2 py-1 bg-indigo-600 text-white rounded-md">
+          <span className="font-medium text-gray-800">{item.title}</span>
+          <button
+            type="button"
+            onClick={() => handleInstantBuy(item.item_id)}
+            className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-600"
+          >
             Instant Buy
           </button>
         </li>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,10 +1,14 @@
 export type Item = {
   item_id: string;
   title: string;
-  brand?: string;
+  brand: string;
   price_usd: number;
   image_url: string;
-  attributes?: Record<string, string>;
+  category?: string;
+  tags?: string[];
+  attributes?: Record<string, unknown>;
+  embedding?: number[];
+  score?: number;
 };
 
 export type UserEvent =
@@ -12,4 +16,25 @@ export type UserEvent =
   | { type: "swipe_dislike"; user_id: string; item_id: string; ts: number; surface: "items" }
   | { type: "detail_view"; user_id: string; item_id: string; ts: number }
   | { type: "add_to_cart"; user_id: string; item_id: string; ts: number }
-  | { type: "purchase"; user_id: string; cart_item_ids: string[]; ts: number };
+  | { type: "purchase"; user_id: string; cart_item_ids: string[]; ts: number }
+  | {
+      type: "share";
+      user_id: string;
+      item_id: string;
+      ts: number;
+      surface: "items" | "portfolio";
+    }
+  | {
+      type: "profile_update";
+      user_id: string;
+      ts: number;
+      profile: {
+        name?: string;
+        email?: string;
+        gender?: "female" | "male" | "nonbinary" | "prefer_not";
+        age?: number;
+        budgetMin?: number;
+        budgetMax?: number;
+        styles?: string[];
+      };
+    };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,52 @@
+import { UserEvent } from "./events";
+
+type CounterKey =
+  | "impressions"
+  | "swipe_like"
+  | "swipe_dislike"
+  | "add_to_cart"
+  | "share"
+  | "purchase";
+
+type MetricsState = Record<CounterKey, number>;
+
+const metrics: MetricsState = {
+  impressions: 0,
+  swipe_like: 0,
+  swipe_dislike: 0,
+  add_to_cart: 0,
+  share: 0,
+  purchase: 0,
+};
+
+export function incrementMetric(key: CounterKey, amount = 1) {
+  metrics[key] += amount;
+}
+
+export function recordEvents(events: UserEvent[]) {
+  for (const event of events) {
+    switch (event.type) {
+      case "swipe_like":
+        incrementMetric("swipe_like");
+        break;
+      case "swipe_dislike":
+        incrementMetric("swipe_dislike");
+        break;
+      case "add_to_cart":
+        incrementMetric("add_to_cart");
+        break;
+      case "purchase":
+        incrementMetric("purchase");
+        break;
+      case "share":
+        incrementMetric("share");
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+export function getMetrics() {
+  return metrics;
+}

--- a/src/lib/recs.ts
+++ b/src/lib/recs.ts
@@ -1,16 +1,83 @@
 import { Item, UserEvent } from "./events";
 
-export async function fetchNextItems(userId: string, k = 10): Promise<Item[]> {
-  // Mock implementation: Replace with API call later
-  return Array.from({ length: k }, (_, i) => ({
-    item_id: `${userId}-${i}`,
-    title: `Item ${i + 1}`,
-    price_usd: Math.random() * 100,
-    image_url: "/placeholder.jpg",
-  }));
+type RecommendationResponse = {
+  recommendations: { item: Item; score: number }[];
+};
+
+type FetchContext = Record<string, unknown>;
+
+async function postJson<T>(url: string, body: unknown, init?: RequestInit) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    ...init,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request to ${url} failed with ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchNextItems(
+  userId: string,
+  k = 10,
+  context: FetchContext = {}
+): Promise<Item[]> {
+  const data = await postJson<RecommendationResponse>("/api/recs/next", {
+    user_id: userId,
+    k,
+    context,
+  });
+
+  console.log("[fetchNextItems] response", data);
+
+  return data.recommendations.map((entry) => entry.item);
 }
 
 export async function sendFeedback(events: UserEvent[]): Promise<void> {
-  // Mock implementation: Replace with API call later
-  console.log("Feedback sent:", events);
+  if (!events.length) return;
+
+  try {
+    console.log("[sendFeedback] sending events", events);
+    await fetch("/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events }),
+      keepalive: true,
+    });
+  } catch (error) {
+    console.error("Failed to send feedback", error);
+  }
+}
+
+export async function emitShare(
+  userId: string,
+  itemId: string,
+  surface: "items" | "portfolio" = "items"
+) {
+  const event: UserEvent = {
+    type: "share",
+    user_id: userId,
+    item_id: itemId,
+    surface,
+    ts: Date.now(),
+  };
+
+  console.log("[emitShare] sharing", { userId, itemId, surface });
+  await sendFeedback([event]);
+}
+
+export async function instantBuy(userId: string, itemId: string) {
+  const event: UserEvent = {
+    type: "purchase",
+    user_id: userId,
+    cart_item_ids: [itemId],
+    ts: Date.now(),
+  };
+
+  console.log("[instantBuy] purchasing", { userId, itemId });
+  await sendFeedback([event]);
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,10 +1,22 @@
 import { create } from "zustand";
-import { persist, PersistOptions } from "zustand/middleware";
+import { persist } from "zustand/middleware";
 import { Item } from "./events";
+
+export type UserProfile = {
+  name: string;
+  email: string;
+  gender: "female" | "male" | "nonbinary" | "prefer_not";
+  age?: number;
+  budgetMin?: number;
+  budgetMax?: number;
+  styles: string[];
+};
 
 interface UserState {
   userId: string;
+  profile: UserProfile;
   setUserId: (id: string) => void;
+  setProfile: (profile: UserProfile) => void;
 }
 
 interface DeckState {
@@ -19,19 +31,36 @@ interface LikesState {
   remove: (id: string) => void;
 }
 
+export type CartEntry = {
+  item: Item;
+  qty: number;
+};
+
 interface CartState {
-  cart: Item[];
+  cart: CartEntry[];
   add: (item: Item) => void;
   remove: (id: string) => void;
   clear: () => void;
 }
 
-type PersistedState<T> = T & PersistOptions<T>;
+const defaultProfile: UserProfile = {
+  name: "",
+  email: "",
+  gender: "prefer_not",
+  styles: [],
+};
 
-export const useUserStore = create<UserState>((set) => ({
-  userId: "",
-  setUserId: (id: string) => set({ userId: id }),
-}));
+export const useUserStore = create(
+  persist<UserState>(
+    (set) => ({
+      userId: "demo-user",
+      profile: defaultProfile,
+      setUserId: (id: string) => set({ userId: id }),
+      setProfile: (profile: UserProfile) => set({ profile }),
+    }),
+    { name: "user-storage" }
+  )
+);
 
 export const useDeckStore = create<DeckState>((set) => ({
   items: [],
@@ -43,7 +72,13 @@ export const useLikesStore = create(
   persist<LikesState>(
     (set) => ({
       likes: [],
-      add: (item: Item) => set((state) => ({ likes: [...state.likes, item] })),
+      add: (item: Item) =>
+        set((state) => {
+          if (state.likes.some((like) => like.item_id === item.item_id)) {
+            return state;
+          }
+          return { likes: [...state.likes, item] };
+        }),
       remove: (id: string) =>
         set((state) => ({ likes: state.likes.filter((item) => item.item_id !== id) })),
     }),
@@ -55,9 +90,22 @@ export const useCartStore = create(
   persist<CartState>(
     (set) => ({
       cart: [],
-      add: (item: Item) => set((state) => ({ cart: [...state.cart, item] })),
+      add: (item: Item) =>
+        set((state) => {
+          const existing = state.cart.find((entry) => entry.item.item_id === item.item_id);
+          if (existing) {
+            return {
+              cart: state.cart.map((entry) =>
+                entry.item.item_id === item.item_id
+                  ? { ...entry, qty: entry.qty + 1 }
+                  : entry
+              ),
+            };
+          }
+          return { cart: [...state.cart, { item, qty: 1 }] };
+        }),
       remove: (id: string) =>
-        set((state) => ({ cart: state.cart.filter((item) => item.item_id !== id) })),
+        set((state) => ({ cart: state.cart.filter((entry) => entry.item.item_id !== id) })),
       clear: () => set({ cart: [] }),
     }),
     { name: "cart-storage" }

--- a/src/mock/items.json
+++ b/src/mock/items.json
@@ -1,24 +1,152 @@
 [
-  {
-    "item_id": "1",
-    "title": "Red T-Shirt",
-    "brand": "Brand A",
-    "price_usd": 19.99,
-    "image_url": "/images/red-tshirt.jpg",
-    "attributes": {
-      "color": "Red",
-      "size": "M"
-    }
-  },
-  {
-    "item_id": "2",
-    "title": "Blue Jeans",
-    "brand": "Brand B",
-    "price_usd": 49.99,
-    "image_url": "/images/blue-jeans.jpg",
-    "attributes": {
-      "color": "Blue",
-      "size": "32"
-    }
-  }
+{
+"item_id": "1-1859-000001-0124",
+"title": "Wool Blend Fringe Detail Coat",
+"brand": "Olivia TPS x NA-KD",
+"price_usd": 209.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/wool_blend_fringe_detail_coat_1859-000001-0124_3_campaign.jpg?ref=7321AF56DE",
+"category": "coat",
+"tags": ["camel","beige"],
+"attributes": {
+ "color": "Camel",
+ "product_url": "https://www.na-kd.com/en/products/wool-blend-fringe-detail-coat-camel-1859-000001-0124",
+ "gender": "female",
+ "sizes": ["xs","s","m","l"]
+ }
+},
+{
+"item_id": "1-1859-000000-5786",
+"title": "Corduroy Detail Jacket",
+"brand": "Olivia TPS x NA-KD",
+"price_usd": 139.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/corduroy_detail_jacket_1859-000000-5786_4_campaign.jpg?ref=91FC6664BD",
+"category": "jacket",
+"tags": ["beige","print"],
+"attributes": {
+ "color": "Beige Print",
+ "product_url": "https://www.na-kd.com/en/products/corduroy-detail-jacket-beige-print-1859-000000-5786",
+ "gender": "female",
+ "sizes": ["s","m","l"]
+ }
+},
+{
+"item_id": "1-1100-010799-0315",
+"title": "Suede Jacket",
+"brand": "",
+"price_usd": 309.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/suede_jacket-1100-010799-0315_campaign_2.jpg?ref=392817AF74",
+"category": "jacket",
+"tags": ["cognac","brown"],
+"attributes": {
+ "color": "Cognac",
+ "product_url": "https://www.na-kd.com/en/products/suede-jacket-cognac-1100-010799-0315",
+ "gender": "unisex",
+ "sizes": ["m","l","xl"]
+ }
+},
+{
+"item_id": "1-1100-009610-0017",
+"title": "Wool Blend Coat",
+"brand": "",
+"price_usd": 149.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/wool_blend_oversized_coat_1100-009610-0017_0023.jpg?ref=FB4DB73E4B",
+"category": "coat",
+"tags": ["brown","black","dark_grey"],
+"attributes": {
+ "color": "Brown",
+ "product_url": "https://www.na-kd.com/en/products/wool-blend-oversized-coat-brown-1100-009610-0017",
+ "gender": "female",
+ "sizes": ["s","m","l","xl"]
+ }
+},
+{
+"item_id": "1-1859-000013-0017",
+"title": "Regular Fit Blazer With Check Details",
+"brand": "Olivia TPS x NA-KD",
+"price_usd": 99.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/regular_fit_checked_detail_blazer_1859-000013-0017_82_campaign.jpg?ref=64B5DEB655",
+"category": "blazer",
+"tags": ["checkered","brown"],
+"attributes": {
+ "color": "Brown",
+ "product_url": "https://www.na-kd.com/en/products/regular-fit-checked-detail-blazer-brown-1859-000013-0017",
+ "gender": "female",
+ "sizes": ["xs","s","m"]
+ }
+},
+{
+"item_id": "1-1100-010184-0001",
+"title": "Sculpted Blazer",
+"brand": "",
+"price_usd": 99.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/emmaaavo__1100-010184-0001_social.jpg?ref=7354A91A47",
+"category": "blazer",
+"tags": ["white","black","brown"],
+"attributes": {
+ "color": "White",
+ "product_url": "https://www.na-kd.com/en/products/sculpted-blazer-white-1100-010184-0001",
+ "gender": "female",
+ "sizes": ["xs","s","m","l"]
+ }
+},
+{
+"item_id": "1-1018-008235-1230",
+"title": "Low Waist Jeans",
+"brand": "",
+"price_usd": 75.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/low_waist_jeans-1018-008235-12305591649.jpg?ref=36AC67832F",
+"category": "jeans",
+"tags": ["dark_grey","blue","black"],
+"attributes": {
+ "color": "DK Grey",
+ "product_url": "https://www.na-kd.com/en/products/super-low-waist-y2k-jeans-dk-grey-1018-008235-1230",
+ "gender": "female",
+ "sizes": ["xs","s","m","l","xl"]
+ }
+},
+{
+"item_id": "1-1100-009610-0002",
+"title": "Wool Blend Coat",
+"brand": "",
+"price_usd": 149.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/wool_blend_oversized_coat_1100-009610-0002_0040.jpg?ref=AA6F76D7EB",
+"category": "coat",
+"tags": ["black","brown","dark_grey"],
+"attributes": {
+ "color": "Black",
+ "product_url": "https://www.na-kd.com/en/products/wool-blend-oversized-coat-black-1100-009610-0002",
+ "gender": "unisex",
+ "sizes": ["s","m","l","xl"]
+ }
+},
+{
+"item_id": "1-1708-000079-1844",
+"title": "Oversized Long Trenchcoat",
+"brand": "Josefine HJ x NA-KD",
+"price_usd": 149.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/oversized_long_trenchcoat_1708-000079-1844_0033.jpg?ref=62108E6F4C",
+"category": "trenchcoat",
+"tags": ["dark_beige","grey"],
+"attributes": {
+ "color": "Dark Beige",
+ "product_url": "https://www.na-kd.com/en/products/oversized-long-trenchcoat-dark-beige-1708-000079-1844",
+ "gender": "unisex",
+ "sizes": ["m","l","xl"]
+ }
+},
+{
+"item_id": "1-1100-010184-0002",
+"title": "Sculpted Blazer",
+"brand": "",
+"price_usd": 99.95,
+"image_url": "https://www.na-kd.com/cdn-cgi/image/width=300,quality=80,sharpen=0.3/globalassets/sculpted_blazer_1100-010184-0002embroderied_maxi_skirt_1100-010545-000219173.jpg?ref=B5E09A8B70",
+"category": "blazer",
+"tags": ["black","white","brown"],
+"attributes": {
+ "color": "Black",
+ "product_url": "https://www.na-kd.com/en/products/sculpted-blazer-black-1100-010184-0002",
+ "gender": "female",
+ "sizes": ["xs","s","m","l"]
+ }
+}
 ]


### PR DESCRIPTION
feat: wire swipe deck to API, add feedback pipeline, filters, and image domains

Implement Next.js API stubs:
POST /api/recs/next -> returns mock recommendations with scores from src/mock/items.json POST /api/feedback -> accepts batched UserEvent[] and records counters Add in-memory metrics (src/lib/metrics.ts) and wire to API routes Data layer (src/lib/recs.ts):
fetchNextItems via POST /api/recs/next (preserves score on item) sendFeedback with keepalive + emitShare/instantBuy helpers Items page (src/app/items/page.tsx):
Replace hardcoded items with live fetch
Add filters (gender/price/brand/size) with modal UIs Hook swipe left/right, add-to-cart, and share into feedback pipeline Show likes count from Zustand store
SwipeDeck (src/components/SwipeDeck/SwipeDeck.tsx): Add gesture, keyboard, and click-to-swipe with exit animations Expose onSwipeLeft/onSwipeRight/onAddToCart/onShare callbacks ProductCard (src/components/SwipeDeck/ProductCard.tsx): Use next/image with fill/sizes; currency + brand fallback; action buttons State (src/lib/store.ts): persist user/likes/cart; cart quantities; dedupe likes Config (next.config.ts): allow remote images (unsplash + na-kd) so product images render